### PR TITLE
Enable adding multiple ACs

### DIFF
--- a/custom_components/windmillac/__init__.py
+++ b/custom_components/windmillac/__init__.py
@@ -19,14 +19,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = WindmillDataUpdateCoordinator(hass, blynk_service)
 
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN]["coordinator"] = coordinator
+    hass.data[DOMAIN][entry.entry_id] = {
+        "coordinator": coordinator,
+    }
 
     await coordinator.async_config_entry_first_refresh()
 
     for platform in PLATFORMS:
         _LOGGER.debug(f"Loading platform: {platform}")
         hass.async_create_task(
-          hass.config_entries.async_forward_entry_setup(entry, platform)
+            hass.config_entries.async_forward_entry_setup(entry, platform)
         )
 
     return True
@@ -35,6 +37,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hass.data[DOMAIN].pop("coordinator")
+        hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok

--- a/custom_components/windmillac/climate.py
+++ b/custom_components/windmillac/climate.py
@@ -23,7 +23,7 @@ ENTITY_DESCRIPTIONS = [
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
     """Set up the Windmill AC climate entity."""
-    coordinator = hass.data[DOMAIN]["coordinator"]
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
 
     async_add_entities(
         WindmillClimate(

--- a/custom_components/windmillac/entity.py
+++ b/custom_components/windmillac/entity.py
@@ -20,7 +20,7 @@ class WindmillClimate(CoordinatorEntity, ClimateEntity):
         self.entity_description = entity_description
         self._attr_name = "Windmill Climate"
         self._attr_temperature_unit = UnitOfTemperature.FAHRENHEIT
-        self._attr_unique_id = f"{DOMAIN}_{entity_description.key}"
+        self._attr_unique_id = f"{DOMAIN}_{coordinator.blynk_service.token}_{entity_description.key}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self.unique_id)},
             name= "Windmill AC",
@@ -44,7 +44,7 @@ class WindmillClimate(CoordinatorEntity, ClimateEntity):
     @property
     def unique_id(self):
         """Return a unique ID for the entity."""
-        return f"{DOMAIN}_{self.entity_description.key}"
+        return f"{DOMAIN}_{self.coordinator.blynk_service.token}_{self.entity_description.key}"
 
     @property
     def name(self):


### PR DESCRIPTION
These minor changes allow for the integration to support controlling multiple ACs. After adding the integration and configuring the first AC, you can navigate to the integration and hit "Add Device" to create devices/entities for additional ACs. Seems to be working as expected for me and my 2 Windmill units so far.