### PR TITLE
Fix for Home Assistant 2025.6

### DIFF
--- a/custom_components/windmillac/__init__.py
+++ b/custom_components/windmillac/__init__.py
@@ -25,11 +25,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_config_entry_first_refresh()
 
-    for platform in PLATFORMS:
-        _LOGGER.debug(f"Loading platform: {platform}")
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, platform)
-        )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 

--- a/custom_components/windmillac/const.py
+++ b/custom_components/windmillac/const.py
@@ -5,7 +5,7 @@ LOGGER: Logger = getLogger(__package__)
 
 NAME = "WindmillAC"
 DOMAIN = "windmillac"
-VERSION = "1.0.3"
+VERSION = "1.0.4"
 PLATFORMS = ["climate"]
 UPDATE_INTERVAL = 60
 CONF_TOKEN = "token"


### PR DESCRIPTION
Fix for issue #26 

Minor change to update call to _hass.config_entries.async_forward_entry_setup_, which was depreciated in 2025.6

https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/

Also bumped version

