### PR TITLE
fix: breaking HA change

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,5 +98,9 @@ This might occur if something wasn't right the first time you added the device. 
 This is a community-maintained integration (v1). The developer welcomes community support, feedback, and contributions. For issues or feature requests, please use the [GitHub Issues](https://github.com/bzellman/WindmillAC/issues) page.
 
 ## Disclaimer
+## Notes / Changelog
+
+2024-09: Replaced deprecated Home Assistant call `async_forward_entry_setups` with the recommended `async_setup_platforms` in `__init__.py` (see HA June 2024 dev blog).
+
 
 I do my best to maintain this integration but offer no guarantee or warranty for your hardware, software, or devices. The integration may break if Windmill changes their API or technology stack.

--- a/custom_components/windmillac/__init__.py
+++ b/custom_components/windmillac/__init__.py
@@ -25,7 +25,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_config_entry_first_refresh()
 
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    # Forward the platforms for this config entry.
+    # async_forward_entry_setups was deprecated; use async_setup_platforms instead.
+    await hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
     return True
 

--- a/custom_components/windmillac/const.py
+++ b/custom_components/windmillac/const.py
@@ -5,7 +5,7 @@ LOGGER: Logger = getLogger(__package__)
 
 NAME = "WindmillAC"
 DOMAIN = "windmillac"
-VERSION = "1.0.4"
+VERSION = "1.0.5"
 PLATFORMS = ["climate"]
 UPDATE_INTERVAL = 60
 CONF_TOKEN = "token"

--- a/custom_components/windmillac/manifest.json
+++ b/custom_components/windmillac/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/bzellman/HACS-WindmillAC",
   "requirements": ["requests", "blynklib"],
-  "version": "1.0.4"
+  "version": "1.0.5"
 }


### PR DESCRIPTION
This pull request updates the WindmillAC Home Assistant integration to address a recent deprecation and improve documentation. The most important changes are the migration to the recommended setup method for platforms, version bump, and an updated changelog.

**Migration to new Home Assistant API:**
* Replaced deprecated `async_forward_entry_setups` with the recommended `async_setup_platforms` in `custom_components/windmillac/__init__.py`, ensuring compatibility with newer Home Assistant versions.

**Version and documentation updates:**
* Updated the integration version to `1.0.5` in both `custom_components/windmillac/const.py` and `custom_components/windmillac/manifest.json`. [[1]](diffhunk://#diff-e01b476ed4de076a68cc0d3992cab3dfe8afec50993595c6d2b067d420d42202L8-R8) [[2]](diffhunk://#diff-769b36ea53c95975e037ebf7c15cf3b569cb489fd81a138869baa53895787a01L11-R11)
* Added a new "Notes / Changelog" section to `README.md` documenting the API migration and referencing the Home Assistant June 2024 developer blog.