### PR TITLE
Add power (W) and energy (kWh) sensors for Windmill AC units

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ This is a community-maintained integration (v1). The developer welcomes communit
 ## Disclaimer
 ## Notes / Changelog
 
+2026-08: Added `sensor` entities for **Power Consumption** (W) and **Energy** (kWh), so power draw and cumulative usage now show up in Home Assistant (resolves [#30](https://github.com/bzellman/WindmillAC/issues/30)) and can feed the Energy dashboard/long-term statistics ([#41](https://github.com/bzellman/WindmillAC/issues/41)).
+
 2024-09: Replaced deprecated Home Assistant call `async_forward_entry_setups` with the recommended `async_setup_platforms` in `__init__.py` (see HA June 2024 dev blog).
 
 

--- a/custom_components/windmillac/blynk_service.py
+++ b/custom_components/windmillac/blynk_service.py
@@ -2,6 +2,7 @@ import logging
 import requests
 from urllib.parse import urlencode
 from homeassistant.components.climate.const import HVACMode, ClimateEntityFeature
+from .const import PIN_POWER_CONSUMPTION, PIN_ENERGY
 
 _LOGGER = logging.getLogger(__name__)
 _LOGGER.setLevel(logging.DEBUG)
@@ -56,7 +57,7 @@ class BlynkService:
                             return float(response.text)
                         except ValueError:
                             return response.json()[0]
-                except (ValueError, IndexError, TypeError) as e:
+                except (ValueError, IndexError, TypeError, KeyError) as e:
                     raise Exception(f"Failed to parse response for {pin}: {e}")
             else:
                 raise Exception(f"Failed to get pin value for {pin}")
@@ -131,23 +132,31 @@ class BlynkService:
             return HVACMode.OFF
 
 
-    async def async_get_power_consumption(self):
-        """Get the current instantaneous power draw, in Watts."""
-        pin_value = await self.async_get_pin_value('V15')
-        _LOGGER.debug(f"Pin value received for power consumption: {pin_value} (type: {type(pin_value)})")
+    async def _async_get_float_pin(self, pin, label):
+        """Fetch a pin and coerce it to float.
+
+        Returns None (instead of raising) if the pin doesn't exist on this
+        device/firmware, the request fails, or the value isn't numeric —
+        callers treat this pin as optional/best-effort telemetry.
+        """
+        try:
+            pin_value = await self.async_get_pin_value(pin)
+        except Exception as err:
+            _LOGGER.warning(f"Pin {pin} ({label}) is unavailable: {err}")
+            return None
+        _LOGGER.debug(f"Pin value received for {label}: {pin_value} (type: {type(pin_value)})")
         try:
             return float(pin_value)
         except (TypeError, ValueError):
             return None
 
+    async def async_get_power_consumption(self):
+        """Get the current instantaneous power draw, in Watts."""
+        return await self._async_get_float_pin(PIN_POWER_CONSUMPTION, "power consumption")
+
     async def async_get_energy(self):
         """Get the cumulative energy consumption, in kWh."""
-        pin_value = await self.async_get_pin_value('V16')
-        _LOGGER.debug(f"Pin value received for energy: {pin_value} (type: {type(pin_value)})")
-        try:
-            return float(pin_value)
-        except (TypeError, ValueError):
-            return None
+        return await self._async_get_float_pin(PIN_ENERGY, "energy")
 
     async def async_get_fan(self):
         pin_value = await self.async_get_pin_value('V4')

--- a/custom_components/windmillac/blynk_service.py
+++ b/custom_components/windmillac/blynk_service.py
@@ -51,8 +51,12 @@ class BlynkService:
                     elif response.text.isalpha():
                         return response.text.strip()
                     else:
-                        return response.json()[0]
-                except (ValueError, IndexError) as e:
+                        try:
+                            # Handles decimal values like power (W) and energy (kWh) pins
+                            return float(response.text)
+                        except ValueError:
+                            return response.json()[0]
+                except (ValueError, IndexError, TypeError) as e:
                     raise Exception(f"Failed to parse response for {pin}: {e}")
             else:
                 raise Exception(f"Failed to get pin value for {pin}")
@@ -126,6 +130,24 @@ class BlynkService:
         else:
             return HVACMode.OFF
 
+
+    async def async_get_power_consumption(self):
+        """Get the current instantaneous power draw, in Watts."""
+        pin_value = await self.async_get_pin_value('V15')
+        _LOGGER.debug(f"Pin value received for power consumption: {pin_value} (type: {type(pin_value)})")
+        try:
+            return float(pin_value)
+        except (TypeError, ValueError):
+            return None
+
+    async def async_get_energy(self):
+        """Get the cumulative energy consumption, in kWh."""
+        pin_value = await self.async_get_pin_value('V16')
+        _LOGGER.debug(f"Pin value received for energy: {pin_value} (type: {type(pin_value)})")
+        try:
+            return float(pin_value)
+        except (TypeError, ValueError):
+            return None
 
     async def async_get_fan(self):
         pin_value = await self.async_get_pin_value('V4')

--- a/custom_components/windmillac/const.py
+++ b/custom_components/windmillac/const.py
@@ -5,8 +5,8 @@ LOGGER: Logger = getLogger(__package__)
 
 NAME = "WindmillAC"
 DOMAIN = "windmillac"
-VERSION = "1.0.6"
-PLATFORMS = ["climate"]
+VERSION = "1.1.0"
+PLATFORMS = ["climate", "sensor"]
 UPDATE_INTERVAL = 60
 CONF_TOKEN = "token"
 BASE_URL = "https://dashboard.windmillair.com"

--- a/custom_components/windmillac/const.py
+++ b/custom_components/windmillac/const.py
@@ -10,3 +10,11 @@ PLATFORMS = ["climate", "sensor"]
 UPDATE_INTERVAL = 60
 CONF_TOKEN = "token"
 BASE_URL = "https://dashboard.windmillair.com"
+
+# Power/energy telemetry pins, confirmed by probing a live device
+# (Template Id TMPLRK32gafq, firmware 0.4.7). Not guaranteed to exist on
+# every Windmill AC device/firmware/template, so failures reading these
+# are treated as optional/best-effort rather than fatal (see
+# coordinator.py and BlynkService._async_get_float_pin).
+PIN_POWER_CONSUMPTION = "V15"
+PIN_ENERGY = "V16"

--- a/custom_components/windmillac/coordinator.py
+++ b/custom_components/windmillac/coordinator.py
@@ -30,6 +30,8 @@ class WindmillDataUpdateCoordinator(DataUpdateCoordinator):
                 "mode": await self.blynk_service.async_get_mode(),
                 "fan": await self.blynk_service.async_get_fan(),
                 "power": await self.blynk_service.async_get_power(),
+                "power_consumption": await self.blynk_service.async_get_power_consumption(),
+                "energy": await self.blynk_service.async_get_energy(),
             }
             _LOGGER.debug(f"Data fetched from Windmill AC: {data}")
             return data

--- a/custom_components/windmillac/coordinator.py
+++ b/custom_components/windmillac/coordinator.py
@@ -30,11 +30,28 @@ class WindmillDataUpdateCoordinator(DataUpdateCoordinator):
                 "mode": await self.blynk_service.async_get_mode(),
                 "fan": await self.blynk_service.async_get_fan(),
                 "power": await self.blynk_service.async_get_power(),
-                "power_consumption": await self.blynk_service.async_get_power_consumption(),
-                "energy": await self.blynk_service.async_get_energy(),
             }
-            _LOGGER.debug(f"Data fetched from Windmill AC: {data}")
-            return data
         except Exception as err:
             _LOGGER.error(f"Error fetching data: {err}")
             raise UpdateFailed(f"Error fetching data: {err}")
+
+        # Power/energy are optional telemetry pins that aren't confirmed to
+        # exist on every device/firmware. BlynkService already returns None
+        # for them instead of raising, but fetch them outside the block
+        # above and guard again here anyway: a failure here must only make
+        # those two sensors unavailable, never take down the climate entity
+        # or block setup.
+        try:
+            data["power_consumption"] = await self.blynk_service.async_get_power_consumption()
+        except Exception as err:
+            _LOGGER.warning(f"Error fetching power consumption: {err}")
+            data["power_consumption"] = None
+
+        try:
+            data["energy"] = await self.blynk_service.async_get_energy()
+        except Exception as err:
+            _LOGGER.warning(f"Error fetching energy: {err}")
+            data["energy"] = None
+
+        _LOGGER.debug(f"Data fetched from Windmill AC: {data}")
+        return data

--- a/custom_components/windmillac/entity.py
+++ b/custom_components/windmillac/entity.py
@@ -1,7 +1,8 @@
 import logging
 from homeassistant.components.climate import ClimateEntity, ClimateEntityDescription
 from homeassistant.components.climate.const import HVACMode, ClimateEntityFeature
-from homeassistant.const import UnitOfTemperature, ATTR_TEMPERATURE
+from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, SensorStateClass
+from homeassistant.const import UnitOfTemperature, UnitOfPower, UnitOfEnergy, ATTR_TEMPERATURE
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.entity import DeviceInfo
 
@@ -9,6 +10,15 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 _LOGGER.setLevel(logging.DEBUG)
+
+
+def _windmill_ac_device_info(coordinator) -> DeviceInfo:
+    """Build the shared DeviceInfo so all entities for this AC group under one device."""
+    return DeviceInfo(
+        identifiers={(DOMAIN, f"{DOMAIN}_{coordinator.blynk_service.token}_windmill_AC")},
+        name="Windmill AC",
+        manufacturer="Windmill"
+    )
 
 
 class WindmillClimate(CoordinatorEntity, ClimateEntity):
@@ -21,11 +31,7 @@ class WindmillClimate(CoordinatorEntity, ClimateEntity):
         self._attr_name = "Windmill Climate"
         self._attr_temperature_unit = UnitOfTemperature.FAHRENHEIT
         self._attr_unique_id = f"{DOMAIN}_{coordinator.blynk_service.token}_{entity_description.key}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self.unique_id)},
-            name= "Windmill AC",
-            manufacturer="Windmill"
-        )
+        self._attr_device_info = _windmill_ac_device_info(coordinator)
         self._attr_supported_features = (
             ClimateEntityFeature.TARGET_TEMPERATURE |
             ClimateEntityFeature.FAN_MODE |
@@ -127,3 +133,43 @@ class WindmillClimate(CoordinatorEntity, ClimateEntity):
         _LOGGER.debug(f"Updated HVAC mode: {self._attr_hvac_mode}")
         _LOGGER.debug(f"Updated fan mode: {self._attr_fan_mode}")
         _LOGGER.debug(f"Updated power state: {self._attr_is_on}")
+
+
+class WindmillPowerSensor(CoordinatorEntity, SensorEntity):
+    """Representation of the Windmill AC's instantaneous power draw."""
+
+    _attr_device_class = SensorDeviceClass.POWER
+    _attr_native_unit_of_measurement = UnitOfPower.WATT
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator, entity_description):
+        """Initialize the power sensor."""
+        super().__init__(coordinator)
+        self.entity_description = entity_description
+        self._attr_unique_id = f"{DOMAIN}_{coordinator.blynk_service.token}_{entity_description.key}"
+        self._attr_device_info = _windmill_ac_device_info(coordinator)
+
+    @property
+    def native_value(self):
+        """Return the current power draw, in Watts."""
+        return self.coordinator.data.get("power_consumption")
+
+
+class WindmillEnergySensor(CoordinatorEntity, SensorEntity):
+    """Representation of the Windmill AC's cumulative energy consumption."""
+
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+
+    def __init__(self, coordinator, entity_description):
+        """Initialize the energy sensor."""
+        super().__init__(coordinator)
+        self.entity_description = entity_description
+        self._attr_unique_id = f"{DOMAIN}_{coordinator.blynk_service.token}_{entity_description.key}"
+        self._attr_device_info = _windmill_ac_device_info(coordinator)
+
+    @property
+    def native_value(self):
+        """Return the cumulative energy consumption, in kWh."""
+        return self.coordinator.data.get("energy")

--- a/custom_components/windmillac/manifest.json
+++ b/custom_components/windmillac/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/bzellman/HACS-WindmillAC",
   "requirements": ["requests", "blynklib"],
-  "version": "1.0.6"
+  "version": "1.1.0"
 }

--- a/custom_components/windmillac/sensor.py
+++ b/custom_components/windmillac/sensor.py
@@ -1,0 +1,41 @@
+#sensor.py
+
+import logging
+from homeassistant.components.sensor import SensorEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from .const import DOMAIN
+from .coordinator import WindmillDataUpdateCoordinator
+from .entity import WindmillPowerSensor, WindmillEnergySensor
+
+_LOGGER = logging.getLogger(__name__)
+
+
+ENTITY_DESCRIPTIONS = [
+    (
+        SensorEntityDescription(
+            key="windmill_AC_power",
+            name="Windmill AC Power Consumption",
+            icon="mdi:flash",
+        ),
+        WindmillPowerSensor,
+    ),
+    (
+        SensorEntityDescription(
+            key="windmill_AC_energy",
+            name="Windmill AC Energy Consumption",
+            icon="mdi:lightning-bolt",
+        ),
+        WindmillEnergySensor,
+    ),
+]
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
+    """Set up the Windmill AC sensor entities."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+
+    async_add_entities(
+        entity_class(coordinator=coordinator, entity_description=entity_description)
+        for entity_description, entity_class in ENTITY_DESCRIPTIONS
+    )


### PR DESCRIPTION
I recently did some digging with Claude to add power/energy sensors to this integration. I've been testing this on my own home assistant for the past week or so with good results.

I do not have any other devices to test if these pins are reused for other devices, so I can't attest that this is completely safe for other non-AC Windmill devices, we do handle an error in case the pin isn't exposed at all, but nothing if it 'means' something else.

Opening this in case it's useful, but totally cool if you'd like to implement yourself!